### PR TITLE
Run boot on providers after register

### DIFF
--- a/src/Registrar/index.js
+++ b/src/Registrar/index.js
@@ -31,16 +31,29 @@ Registrar.mapProviders = function (arrayOfProviderPaths) {
 }
 
 /**
- * @description requires an array of provider and returns
- * their register method
- * @method require
+ * @description requires an array of provider instances
+ * and runs register foreach provider
+ * @method registerProviders
  * @param  {Array} arrayOfProviders
  * @return {Array}
  * @public
  */
-Registrar.require = function (arrayOfProviders) {
-  return Registrar.mapProviders(arrayOfProviders)
-    .map((provider) => provider.register())
+Registrar.registerProviders = function (arrayOfProviders) {
+  return arrayOfProviders.map((provider) => provider.register())
+}
+
+/**
+ * @description requires an array of provider and returns
+ * their register method
+ * @method require
+ * @param  {Array} arrayOfProviderPaths
+ * @return {Array}
+ * @public
+ */
+Registrar.require = function (arrayOfProviderPaths) {
+  const arrayOfProviders = Registrar.mapProviders(arrayOfProviderPaths)
+
+  return Registrar.registerProviders(arrayOfProviders)
 }
 
 /**
@@ -51,11 +64,10 @@ Registrar.require = function (arrayOfProviders) {
  * @return {void}
  * @public
  */
-Registrar.register = function (arrayOfProviders) {
-  // const providers = Registrar.mapProviders(arrayOfProviders)
-  arrayOfProviders = Registrar.require(arrayOfProviders)
+Registrar.register = function (arrayOfProviderPaths) {
+  const arrayOfProviders = Registrar.mapProviders(arrayOfProviderPaths)
 
   return co(function * () {
-    return yield parallel(arrayOfProviders)
+    return yield parallel(Registrar.registerProviders(arrayOfProviders))
   })
 }

--- a/src/Registrar/index.js
+++ b/src/Registrar/index.js
@@ -43,6 +43,18 @@ Registrar.registerProviders = function (arrayOfProviders) {
 }
 
 /**
+ * @description requires an array of provider instances
+ * and runs boot foreach provider
+ * @method bootProviders
+ * @param  {Array} arrayOfProviders
+ * @return {Array}
+ * @public
+ */
+Registrar.bootProviders = function (arrayOfProviders) {
+  return arrayOfProviders.map((provider) => provider.boot())
+}
+
+/**
  * @description requires an array of provider and returns
  * their register method
  * @method require
@@ -68,6 +80,7 @@ Registrar.register = function (arrayOfProviderPaths) {
   const arrayOfProviders = Registrar.mapProviders(arrayOfProviderPaths)
 
   return co(function * () {
-    return yield parallel(Registrar.registerProviders(arrayOfProviders))
+    yield parallel(Registrar.registerProviders(arrayOfProviders))
+    return yield parallel(Registrar.bootProviders(arrayOfProviders))
   })
 }

--- a/src/ServiceProvider/index.js
+++ b/src/ServiceProvider/index.js
@@ -23,6 +23,10 @@ class ServiceProvider {
     this.app = Ioc
   }
 
+  * boot () {
+
+  }
+
 }
 
 module.exports = ServiceProvider


### PR DESCRIPTION
This Pull Request refactors the Registrar to run both the register and a new `boot` method on service providers.

This should allow a boot method similar to that of Laravel's Service Providers.
The boot method is helpful when registering things like events or macros within addons.
Since the `use` method has to be used, the boot method must wait until AFTER the service providers have all been registered.