### PR TITLE
Short define alias when defining a new binding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 npm-debug.log
 out
 .nyc_output
+.idea

--- a/test/unit/ioc.spec.js
+++ b/test/unit/ioc.spec.js
@@ -117,6 +117,24 @@ test.group('Ioc', function () {
     assert.equal(packageFile.name, '@adonisjs/fold')
   })
 
+  test('should be able to short define aliases for bindings', function () {
+    const ioc = new Ioc()
+    const fooFn = function () {}
+    const barFn = function () {}
+    ioc.alias('Foo').bind('App/Foo', fooFn)
+    ioc.alias('Bar').singleton('App/Bar', barFn)
+
+    assert.equal(ioc.getAliases()['Foo'], 'App/Foo')
+    assert.equal(ioc.getAliases()['Bar'], 'App/Bar')
+  })
+
+  test('should be able to short define aliases for singletons', function () {
+    const ioc = new Ioc()
+    const fooFn = function () {}
+    ioc.alias('Foo').singleton('App/Foo', fooFn)
+    assert.equal(ioc.getAliases()['Foo'], 'App/Foo')
+  })
+
   test('should be able to define aliases for bindings', function () {
     const ioc = new Ioc()
     const fooFn = function () {}


### PR DESCRIPTION
Usage:

```js
Ioc.alias('Helpers').singleton('Adonis/Src/Helpers', ...)
```

Still supports the old way of defining an alias.
Also bindings are being stored in a nested object by using `lodash` and converting the namespaces to dot notation, so you can basically get a better overview of what class belongs to what namespace as they're nested in an object containing the identifier (class) as key and the rest as value

E.g 
```js
Ioc.alias('Config').singleton('Adonis/Src/Config', ...)
Ioc.alias('Env').singleton('Adonis/Src/Env', ...)

// Get bindings
Ioc.getBindings()

// Old way it would return
{
  'Adonis/Src/Config': {},
  'Adonis/Src/Env': {}
}

// Now it simply returns a nested object with an array of identifiers instead
{
  Adonis: {
    Src: { 
      Config: {},
      Env: {}
    }
  }
}
```