### PR TITLE
feat(ioc): add with method

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ ioc.bind('App/Foo', function () {
 
 const foo = ioc.use('App/Foo')
 // return Foo class instance
+
+ioc.with('App/Foo', (Foo) => {
+  // Only if App/Foo exists
+})
 ```
 
 Simple enough! But we do not see the real power of the Ioc container, since we can instantiate the class manually too. Right? NO

--- a/src/Ioc/index.js
+++ b/src/Ioc/index.js
@@ -743,6 +743,25 @@ class Ioc {
   }
 
   /**
+   * @method with
+   *
+   * @param  {string|string[]}  namespaces
+   * @param  {Function}         next
+   * @return {void}
+   */
+  with (namespaces, next) {
+    namespaces = _.isArray(namespaces)
+      ? namespaces
+      : [namespaces]
+
+    try {
+      const resolved = namespaces.map(this.use)
+
+      next(...resolved)
+    } catch (e) {}
+  }
+
+  /**
    * Works as same as the `use` method, but instead returns
    * an instance of the class when resolved value is a
    * ES6 class and not a registered binding. Bindings

--- a/src/Ioc/index.js
+++ b/src/Ioc/index.js
@@ -743,6 +743,9 @@ class Ioc {
   }
 
   /**
+   * Attempts to resolve given namespaces and forward
+   * them to the given callback.
+   *
    * @method with
    *
    * @param  {string|string[]}  namespaces
@@ -755,7 +758,7 @@ class Ioc {
       : [namespaces]
 
     try {
-      const resolved = namespaces.map(this.use)
+      const resolved = namespaces.map(namespace => this.use(namespace))
 
       next(...resolved)
     } catch (e) {}

--- a/test/unit/ioc.spec.js
+++ b/test/unit/ioc.spec.js
@@ -142,7 +142,8 @@ test.group('Ioc', function () {
     assert.equal(ioc.getAutoloads()['App'], path.join(__dirname, './app'))
   })
 
-  test('should be able to call a closure when loading has been successful using with', function () {
+  test('should be able to call a closure when loading has been successful using with', (assert) => {
+    assert.plan(1)
     const ioc = new Ioc()
     const fooFn = function () {
       return 'foo'
@@ -154,7 +155,8 @@ test.group('Ioc', function () {
     })
   })
 
-  test('should be able to call a closure when loading has been successful using with', function () {
+  test('should be able to call a closure when loading has been successful using with', (assert) => {
+    assert.plan(2)
     const ioc = new Ioc()
     const fooFn = function () {
       return 'foo'
@@ -171,7 +173,8 @@ test.group('Ioc', function () {
     })
   })
 
-  test('should fail silently when loading has been unsuccessful using with', function () {
+  test('should fail silently when loading has been unsuccessful using with', (assert) => {
+    assert.plan(1)
     const ioc = new Ioc()
     ioc.with(['App/Foo'], (Foo) => {
       assert.equal(true, false)

--- a/test/unit/ioc.spec.js
+++ b/test/unit/ioc.spec.js
@@ -142,6 +142,44 @@ test.group('Ioc', function () {
     assert.equal(ioc.getAutoloads()['App'], path.join(__dirname, './app'))
   })
 
+  test('should be able to call a closure when loading has been successful using with', function () {
+    const ioc = new Ioc()
+    const fooFn = function () {
+      return 'foo'
+    }
+    ioc.bind('App/Foo', fooFn)
+
+    ioc.with('App/Foo', (Foo) => {
+      assert.equal(Foo, 'foo')
+    })
+  })
+
+  test('should be able to call a closure when loading has been successful using with', function () {
+    const ioc = new Ioc()
+    const fooFn = function () {
+      return 'foo'
+    }
+    const barFn = function () {
+      return 'bar'
+    }
+    ioc.bind('App/Foo', fooFn)
+    ioc.bind('App/Bar', barFn)
+
+    ioc.with(['App/Foo', 'App/Bar'], (Foo, Bar) => {
+      assert.equal(Foo, 'foo')
+      assert.equal(Bar, 'bar')
+    })
+  })
+
+  test('should fail silently when loading has been unsuccessful using with', function () {
+    const ioc = new Ioc()
+    ioc.with(['App/Foo'], (Foo) => {
+      assert.equal(true, false)
+    })
+
+    assert.equal(true, true)
+  })
+
   test('should be able to resolve a file from the autoloaded directory', function () {
     const ioc = new Ioc()
     const actualUserClass = require('./app/User')


### PR DESCRIPTION
This method allows us to run code only when the namespace exists and is available.

Instead of
```js
try {
  const View = this.app.use('Adonis/Src/View')
  const Can = require('../src/ViewBindings/Can')
  const Cannot = require('../src/ViewBindings/Cannot')

  View.tag(new Can())
  View.tag(new Cannot())
} catch (error) {
  // Ignore error when end-user is not using views
}
```

Write
```js
this.app.with('Adonis/Src/View', (View) => {
  const Can = require('../src/ViewBindings/Can')
  const Cannot = require('../src/ViewBindings/Cannot')

  View.tag(new Can())
  View.tag(new Cannot()) 
})
```

**Method signature:**
```ts
with (namespaces: string | string[], next: Function): void
```